### PR TITLE
add suitcase-mongo dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   run:
     - python >=3.6
     - bluesky
+    - suitcase-mongo
     - msgpack-python
     - msgpack-numpy
     - python-confluent-kafka


### PR DESCRIPTION
attempting to resolve this [problem](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=429601&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=531)
```
import: 'bluesky_kafka'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/bluesky-kafka_1639677798661/test_tmp/run_test.py", line 2, in <module>
    import bluesky_kafka
  File "/home/conda/feedstock_root/build_artifacts/bluesky-kafka_1639677798661/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.10/site-packages/bluesky_kafka/__init__.py", line 9, in <module>
    from suitcase import mongo_normalized
ModuleNotFoundError: No module named 'suitcase'
Tests failed for bluesky-kafka-0.8.0-pyhd8ed1ab_0.tar.bz2 - moving package to /home/conda/feedstock_root/build_artifacts/broken

```